### PR TITLE
:bug: Fix use of authenticated connections

### DIFF
--- a/lib/routes/instance.js
+++ b/lib/routes/instance.js
@@ -6,7 +6,7 @@ var boom = require('boom');
 var async = require('async');
 var toNS = require('mongodb-ns');
 var store = require('../models/store');
-var isNotAuthorized = require('mongodb-js-errors');
+var isNotAuthorized = require('mongodb-js-errors').isNotAuthorized;
 var ReadPreference = require('mongodb-read-preference');
 var debug = require('debug')('scout-server:routes:instance');
 


### PR DESCRIPTION
Fixes "TypeError: isNotAuthorized is not a function"
Introduced with mongodb-js-errors in b1faf19

Confirmed locally that Compass master is again able to use authenticated (username/passwd) connections with this change.
