### PR TITLE
boom@3.1.1 untested ⚠️

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "async": "^1.5.0",
     "body-parser": "^1.14.1",
-    "boom": "^3.0.0",
+    "boom": "^3.1.1",
     "bugsnag": "^1.6.6",
     "chalk": "^1.1.1",
     "csv-write-stream": "^1.0.0",


### PR DESCRIPTION
Hello :wave:

:warning::warning::warning:

[boom](https://www.npmjs.com/package/boom) just published its new version 3.1.1, which **is covered by your current version range**. **No automated tests** are configured for this project.

This means it’s now **unclear whether your software still works**. Manually check if that’s still the case
and close this pull request – if it broke, use this branch to work on adaptions and fixes.

<sub>
Do you think getting a pull request for every single new version of your dependencies is too noisy?
Configure continuous integration and you will only receive them when tests fail. 
</sub>


Happy fixing and merging :palm_tree:

---
The new version differs by 11 commits .

- [`d455050`](https://github.com/hapijs/boom/commit/d455050c8d55da4fd092953f639476ed880f090a) `version 3.1.1`
- [`6f0041d`](https://github.com/hapijs/boom/commit/6f0041d7c7c908185c9e926d3b7e5679696f5aaa) `Merge pull request #95 from hapijs/proto`
- [`269ff01`](https://github.com/hapijs/boom/commit/269ff018221eb36eac5bfb0af060b93f8d8213c1) `Changed prototype logic.`
- [`3af172b`](https://github.com/hapijs/boom/commit/3af172b2213a3ec502cdddfc37281243c92e0b4e) `version 3.1.0`
- [`f51f2ee`](https://github.com/hapijs/boom/commit/f51f2eeba5fae1b79f79c14b2c42d110f0433b2c) `Cleanup for 254593fd1d09e79049692675a4f9b7b5108b36d8`
- [`ca3aac4`](https://github.com/hapijs/boom/commit/ca3aac4a868e17802fc3159ae9f58170cccfbea9) `Merge pull request #91 from hapijs/code-451`
- [`254593f`](https://github.com/hapijs/boom/commit/254593fd1d09e79049692675a4f9b7b5108b36d8) `Add new 451 Unavailable For Legal Reasons`
- [`03fc3c4`](https://github.com/hapijs/boom/commit/03fc3c4f8b90ca6104b35328a670b59a37e3223b) `Merge pull request #89 from hapijs/toc`
- [`005a398`](https://github.com/hapijs/boom/commit/005a398cb529a5bbd566e574aafd5785c5ee860a) `Autogenerate table of contents. Closes #86.`
- [`f81417c`](https://github.com/hapijs/boom/commit/f81417ccae679e5378ac580abce3899f8277ed9d) `Merge pull request #85 from mtharrison/master`
- [`ea08443`](https://github.com/hapijs/boom/commit/ea0844327058a15fb9239bd556b9a46704904421) `Fixed typo in README schema => scheme`

See the [full diff](https://github.com/hapijs/boom/compare/9a71a86b5517ef328bdbd0750945da90a15352e8...d455050c8d55da4fd092953f639476ed880f090a).

---
This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>