### PR TITLE
joi@7.1.0 untested ⚠️

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "express": "^4.13.3",
     "figures": "^1.4.0",
     "helmet": "^1.0.1",
-    "joi": "^7.0.1",
+    "joi": "^7.1.0",
     "jsonwebtoken": "^5.4.1",
     "lodash": "^3.10.1",
     "mongodb-collection-sample": "^0.3.1",


### PR DESCRIPTION
Hello :wave:

:warning::warning::warning:

[joi](https://www.npmjs.com/package/joi) just published its new version 7.1.0, which **is covered by your current version range**. **No automated tests** are configured for this project.

This means it’s now **unclear whether your software still works**. Manually check if that’s still the case
and close this pull request – if it broke, use this branch to work on adaptions and fixes.

<sub>
Do you think getting a pull request for every single new version of your dependencies is too noisy?
Configure continuous integration and you will only receive them when tests fail. 
</sub>


Happy fixing and merging :palm_tree:

---
The new version differs by 3 commits .

- [`6cfac4c`](https://github.com/hapijs/joi/commit/6cfac4c81ce935371c8bd0104b53adcb7bb35b14) `7.1.0`
- [`52c1781`](https://github.com/hapijs/joi/commit/52c1781819e95bdd1b011c6430c0a7f37b18f155) `Add isJoi boolean to errors`
- [`ebe00be`](https://github.com/hapijs/joi/commit/ebe00be7277580f54be4f4b975198aedc1e2fba2) `Update to lab 8`

See the [full diff](https://github.com/hapijs/joi/compare/7e28f8d7435e5607da5909a4df756428091b10ba...6cfac4c81ce935371c8bd0104b53adcb7bb35b14).

---
This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>