### PR TITLE
jsonwebtoken@5.5.4 untested ⚠️

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "figures": "^1.4.0",
     "helmet": "^1.0.1",
     "joi": "^7.0.1",
-    "jsonwebtoken": "^5.4.1",
+    "jsonwebtoken": "^5.5.4",
     "lodash": "^3.10.1",
     "mongodb-collection-sample": "^0.3.1",
     "mongodb-connection-model": "^3.0.10",


### PR DESCRIPTION
Hello :wave:

:warning::warning::warning:

[jsonwebtoken](https://www.npmjs.com/package/jsonwebtoken) just published its new version 5.5.4, which **is covered by your current version range**. **No automated tests** are configured for this project.

This means it’s now **unclear whether your software still works**. Manually check if that’s still the case
and close this pull request – if it broke, use this branch to work on adaptions and fixes.

<sub>
Do you think getting a pull request for every single new version of your dependencies is too noisy?
Configure continuous integration and you will only receive them when tests fail. 
</sub>


Happy fixing and merging :palm_tree:

---
The new version differs by 19 commits .

- [`10266c1`](https://github.com/auth0/node-jsonwebtoken/commit/10266c139298af1261fb9592838b1877f82fd4e4) `5.5.4`
- [`46552e7`](https://github.com/auth0/node-jsonwebtoken/commit/46552e7c45025c76e3f647680d7539a66bfac612) `minor`
- [`04a76d5`](https://github.com/auth0/node-jsonwebtoken/commit/04a76d51f1ea7203be6aa14ca92ab0b1e8b8aa07) `5.5.3`
- [`71200f1`](https://github.com/auth0/node-jsonwebtoken/commit/71200f14deba0533d3261266348338fac2d14661) `add a console.warn on invalid options for string payloads`
- [`65b1f58`](https://github.com/auth0/node-jsonwebtoken/commit/65b1f580382dc58dd3da6f47a52713776fd7cdf2) `minor`
- [`e403a66`](https://github.com/auth0/node-jsonwebtoken/commit/e403a66bee5f1aaabe974a7862cc6eaf0b926d57) `5.5.2`
- [`be9c09a`](https://github.com/auth0/node-jsonwebtoken/commit/be9c09af83b09c9e72da8b2c6166fa51d92aeab6) `fix signing method with sealed objects, do not modify the params object. closes #147`
- [`42145bc`](https://github.com/auth0/node-jsonwebtoken/commit/42145bc6ef3a556c170aa4fca3229310ad5c8086) `5.5.1`
- [`786d37b`](https://github.com/auth0/node-jsonwebtoken/commit/786d37b299c67771b5e71a2ca476666ab0f97d98) `fix nbf verification. fix #152`
- [`f1fb176`](https://github.com/auth0/node-jsonwebtoken/commit/f1fb176a1599a6fed82c9ffcf7517c295c5c0541) `5.5.0`
- [`adc1673`](https://github.com/auth0/node-jsonwebtoken/commit/adc1673d13ae8c5a2550adf997cd886c7e1a15af) `Merge branch 'TATDK-master'`
- [`46372e9`](https://github.com/auth0/node-jsonwebtoken/commit/46372e928f6d2e7398f9b88022ca617d2a3b0699) `improvements to nbf and jti claims`
- [`a3c5c23`](https://github.com/auth0/node-jsonwebtoken/commit/a3c5c23f5e76710dd3e1e5347bd9c4e88bd3524c) `Merge branch 'master' of https://github.com/TATDK/node-jsonwebtoken into TATDK-master`
- [`7bb5aa6`](https://github.com/auth0/node-jsonwebtoken/commit/7bb5aa6407dd2b4571da918d2d0af43945359652) `Merge pull request #128 from lukewestby/master`
- [`25cf740`](https://github.com/auth0/node-jsonwebtoken/commit/25cf740ad1b559735e497c4fa3f34b6dad8bc9c7) `Merge pull request #132 from yavorski/master`


There are 19 commits in total. See the [full diff](https://github.com/auth0/node-jsonwebtoken/compare/eb272d6da05b7d19d24a5e749cf026ac2b413abf...10266c139298af1261fb9592838b1877f82fd4e4).

---
This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>