### PR TITLE
socket.io-client@1.4.0 untested ⚠️

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "nodemon": "^1.8.1",
     "numeral": "^1.5.3",
     "pre-commit": "^1.1.2",
-    "socket.io-client": "^1.3.7",
+    "socket.io-client": "^1.4.0",
     "supertest": "^1.1.0"
   }
 }


### PR DESCRIPTION
Hello :wave:

:warning::warning::warning:

[socket.io-client](https://www.npmjs.com/package/socket.io-client) just published its new version 1.4.0, which **is covered by your current version range**. **No automated tests** are configured for this project.

This means it’s now **unclear whether your software still works**. Manually check if that’s still the case
and close this pull request – if it broke, use this branch to work on adaptions and fixes.

<sub>
Do you think getting a pull request for every single new version of your dependencies is too noisy?
Configure continuous integration and you will only receive them when tests fail. 
</sub>


Happy fixing and merging :palm_tree:

---
The new version differs by 91 commits .

- [`9c44eaa`](https://github.com/socketio/socket.io-client/commit/9c44eaa3e7277d63787bca3c85923512591e3f29) `Release 1.4.0`
- [`6580a7f`](https://github.com/socketio/socket.io-client/commit/6580a7f9b50be02c70efe308f7d80501c8d6379b) `package: bump `engine.io-client``
- [`d434ce5`](https://github.com/socketio/socket.io-client/commit/d434ce528ad0e409dedc8849fe5abb6652252d53) `Merge pull request #925 from nkzawa/patch-26`
- [`e0cd41e`](https://github.com/socketio/socket.io-client/commit/e0cd41e2d3ec29e2f939e6c46aed97e451ad7e03) `update .travis.yml`
- [`5ccf588`](https://github.com/socketio/socket.io-client/commit/5ccf58873b6a285d8f9ce90c949a49f9ab86ff52) `Merge pull request #924 from nkzawa/patch-25`
- [`5721682`](https://github.com/socketio/socket.io-client/commit/5721682e139f46cbedff9392a0996411d741c41e) `Merge pull request #923 from nkzawa/patch-24`
- [`6ee4283`](https://github.com/socketio/socket.io-client/commit/6ee4283da0d4b9787bb12bb6e2d6d40c0c4b966a) `enable to run all tests on nodejs`
- [`4195680`](https://github.com/socketio/socket.io-client/commit/41956806a7d4da382c043d15efb2abe7c21a24d9) `fix a socket can't connect while disconnecting a different one`
- [`af4d504`](https://github.com/socketio/socket.io-client/commit/af4d504cd8a67b97f410735da37476c3bc412bfa) `Merge pull request #841 from capaj/master`
- [`29eeddc`](https://github.com/socketio/socket.io-client/commit/29eeddcfaa4a219ea8000f398dca874d160141b4) `Merge pull request #919 from nkzawa/patch-19`
- [`a64a1a3`](https://github.com/socketio/socket.io-client/commit/a64a1a31429b03cde0ca949b589ecfa6d6581e55) `Merge pull request #920 from nkzawa/patch-20`
- [`64e65aa`](https://github.com/socketio/socket.io-client/commit/64e65aae7e02cfcf4fb994c84fa906fe3756cd2b) `Merge pull request #921 from nkzawa/patch-21`
- [`2561eb8`](https://github.com/socketio/socket.io-client/commit/2561eb8fbf57802beee4d097c6d540cb446d52d3) `Merge pull request #922 from nkzawa/patch-22`
- [`18be967`](https://github.com/socketio/socket.io-client/commit/18be967adb3810acd77184e50357a7493e6037b7) `ipv6 support`
- [`3313401`](https://github.com/socketio/socket.io-client/commit/33134010828794e0fa7164e4deca49fc78f70280) `fix an unstable test`


There are 91 commits in total. See the [full diff](https://github.com/socketio/socket.io-client/compare/3fe5c2a26c82f195c0872a4cffabb421f0d73748...9c44eaa3e7277d63787bca3c85923512591e3f29).

---
This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>