### PR TITLE
socket.io@1.4.0 untested ⚠️

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "mongodb-replicaset": "^0.1.1",
     "mongodb-sharding": "^0.1.2",
     "mongoscope-config": "^0.1.0",
-    "socket.io": "^1.3.7",
+    "socket.io": "^1.4.0",
     "socket.io-stream": "0.9.0",
     "socketio-jwt": "^4.3.3",
     "uuid": "^2.0.1"


### PR DESCRIPTION
Hello :wave:

:warning::warning::warning:

[socket.io](https://www.npmjs.com/package/socket.io) just published its new version 1.4.0, which **is covered by your current version range**. **No automated tests** are configured for this project.

This means it’s now **unclear whether your software still works**. Manually check if that’s still the case
and close this pull request – if it broke, use this branch to work on adaptions and fixes.

<sub>
Do you think getting a pull request for every single new version of your dependencies is too noisy?
Configure continuous integration and you will only receive them when tests fail. 
</sub>


Happy fixing and merging :palm_tree:

---
The new version differs by 97 commits .

- [`ddb3445`](https://github.com/socketio/socket.io/commit/ddb3445f3d9009554577bbd05b033031e20e23d8) `Release 1.4.0`
- [`6eb9807`](https://github.com/socketio/socket.io/commit/6eb9807f178bf0903fb52f5d1092d34d4c1194ee) `package: bump `engine.io` for sec advisory`
- [`7b0073c`](https://github.com/socketio/socket.io/commit/7b0073c00f3ee775e8d65066e3f435406257acc9) `Merge pull request #2335 from nkzawa/patch-7`
- [`0313ad0`](https://github.com/socketio/socket.io/commit/0313ad0ea335892b77a522762d4d889c0df656e4) `improve the chat demo`
- [`d310d42`](https://github.com/socketio/socket.io/commit/d310d4247283ef093690b69058db3d9341569158) `package: bump `engine.io``
- [`709ceba`](https://github.com/socketio/socket.io/commit/709ceba00a0ea1de2c88a231c39a5c3fe6d7939d) `package: bump `socket.io-adapter` for release`
- [`b29312b`](https://github.com/socketio/socket.io/commit/b29312bc61e780d7b939ae5d7cd505f274a11f96) `package: bump `engine.io` for node 0.8 fix`
- [`5190116`](https://github.com/socketio/socket.io/commit/51901160df360d5c51b24808b99d3847c00eb804) `package: temporarily revert version for tests`
- [`ab1b36e`](https://github.com/socketio/socket.io/commit/ab1b36e13fcf65e421692704de218bbb631dd048) `package: bump `engine.io` for `ws` memory fix`
- [`f7a2f35`](https://github.com/socketio/socket.io/commit/f7a2f3559038bdfa6e699be11b21f8c91047b43c) `package: bump `engine.io``
- [`c348737`](https://github.com/socketio/socket.io/commit/c348737fe61f98ce5113fd68359ae989fe012160) `socket.io: increase large binary data test timeout`
- [`dde3737`](https://github.com/socketio/socket.io/commit/dde37371656b22203d98ee7278655e38f3ab5cc0) `package: bump `engine.io` for release`
- [`8df4c79`](https://github.com/socketio/socket.io/commit/8df4c7931bcd2fe8d67fd5e9fc871830119bc117) `Merge pull request #2325 from darrachequesne/patch-2`
- [`1dfacc6`](https://github.com/socketio/socket.io/commit/1dfacc664732e641a331fcaf7a070df90b098a70) `Trigger callback even when joining an already joined room`
- [`35a0fe0`](https://github.com/socketio/socket.io/commit/35a0fe03778d62bdd14b4563a47af83da7b33b1a) `package: bump parser`


There are 97 commits in total. See the [full diff](https://github.com/socketio/socket.io/compare/e2ebd4349bf27c3839fc9a2700b42cf8390ac3bd...ddb3445f3d9009554577bbd05b033031e20e23d8).

---
This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>