### PR TITLE
minor: update ejson methods to not use deprecated version

### DIFF
--- a/lib/middleware/typed-params.js
+++ b/lib/middleware/typed-params.js
@@ -31,7 +31,7 @@ module.exports = function(req, res, next) {
     // socket.io has already done JSON.parse
     // so just deflate any values into proper
     // BSON instances.
-    return EJSON.deflate(value);
+    return EJSON.deserialize(value);
   };
 
   req.int = function(key, _default) {

--- a/test/token.test.js
+++ b/test/token.test.js
@@ -67,7 +67,7 @@ describe('Tokens', function() {
               return done(err);
             }
 
-            token = EJSON.deflate(res.body);
+            token = EJSON.deserialize(res.body);
             done();
           });
       });


### PR DESCRIPTION
After this, once `mongodb` and `mognodb-instance-model` are updated, tests pass locally.